### PR TITLE
Extend threadsafety to ActiveResource::Base.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rails', github: 'rails/rails'
-gem 'rails-observers', github: 'rails/rails-observers'
+# gem 'rails', github: 'rails/rails'
+# gem 'rails-observers', github: 'rails/rails-observers'
 
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -51,8 +51,8 @@ end
 
 # Publishing ------------------------------------------------------
 
-spec = eval(File.read('activeresource.gemspec'))
-gem = "pkg/activeresource-#{spec.version}.gem"
+spec = eval(File.read('activeresource-threadsafe.gemspec'))
+gem = "pkg/activeresource-threadsafe-#{spec.version}.gem"
 tag = "v#{spec.version}"
 
 desc "Release to rubygems.org"

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -298,7 +298,7 @@ module ActiveResource
 
     class << self
       include ThreadsafeAttributes
-      threadsafe_attribute :_headers, :_connection, :_user, :_password, :_site
+      threadsafe_attribute :_headers, :_connection, :_user, :_password, :_site, :_proxy
 
       # Creates a schema for this resource - setting the attributes that are
       # known prior to fetching an instance from the remote system.
@@ -459,8 +459,8 @@ module ActiveResource
       # Gets the \proxy variable if a proxy is required
       def proxy
         # Not using superclass_delegating_reader. See +site+ for explanation
-        if defined?(@proxy)
-          @proxy
+        if _proxy_defined?
+          _proxy
         elsif superclass != Object && superclass.proxy
           superclass.proxy.dup.freeze
         end
@@ -469,7 +469,7 @@ module ActiveResource
       # Sets the URI of the http proxy to the value in the +proxy+ argument.
       def proxy=(proxy)
         self._connection = nil
-        @proxy = proxy.nil? ? nil : create_proxy_uri_from(proxy)
+        self._proxy = proxy.nil? ? nil : create_proxy_uri_from(proxy)
       end
 
       # Gets the \user for REST HTTP authentication.

--- a/lib/active_resource/threadsafe_attributes.rb
+++ b/lib/active_resource/threadsafe_attributes.rb
@@ -1,0 +1,57 @@
+module ThreadsafeAttributes
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def threadsafe_attribute(*attrs)
+      attrs.each do |attr|
+        define_method attr do
+          get_threadsafe_attribute(attr)
+        end
+
+        define_method "#{attr}=" do |value|
+          set_threadsafe_attribute(attr, value)
+        end
+
+        define_method "#{attr}_defined?" do
+          threadsafe_attribute_defined?(attr)
+        end
+      end
+    end
+  end
+
+  private
+
+  def get_threadsafe_attribute(name)
+    if threadsafe_attribute_defined_by_thread?(name, Thread.current)
+      get_threadsafe_attribute_by_thread(name, Thread.current)
+    elsif threadsafe_attribute_defined_by_thread?(name, Thread.main)
+      get_threadsafe_attribute_by_thread(name, Thread.main).dup.tap do |value|
+        set_threadsafe_attribute_by_thread(name, value, Thread.current)
+      end
+    end
+  end
+
+  def set_threadsafe_attribute(name, value)
+    set_threadsafe_attribute_by_thread(name, value, Thread.current)
+  end
+
+  def threadsafe_attribute_defined?(name)
+    threadsafe_attribute_defined_by_thread?(name, Thread.current) || ((Thread.current != Thread.main) && threadsafe_attribute_defined_by_thread?(name, Thread.main))
+  end
+
+  def get_threadsafe_attribute_by_thread(name, thread)
+    thread["active.resource.#{name}.#{self.object_id}"]
+  end
+
+  def set_threadsafe_attribute_by_thread(name, value, thread)
+    thread["active.resource.#{name}.#{self.object_id}.defined"] = true
+    thread["active.resource.#{name}.#{self.object_id}"] = value
+  end
+
+  def threadsafe_attribute_defined_by_thread?(name, thread)
+    thread["active.resource.#{name}.#{self.object_id}.defined"]
+  end
+
+end

--- a/lib/active_resource/version.rb
+++ b/lib/active_resource/version.rb
@@ -5,7 +5,6 @@ module ActiveResource
     MINOR = 2
     TINY  = 0
 
-    # the PRE string is used to detect that we're using threadsafe in other gems
     PRE  = 'threadsafe'
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -1,0 +1,38 @@
+class ThreadsafeAttributesTest < ActiveSupport::TestCase
+
+  class TestClass
+    include ThreadsafeAttributes
+    threadsafe_attribute :safeattr
+  end
+
+  setup do
+    @tester = TestClass.new
+  end
+
+  test "#threadsafe attributes work in a single thread" do
+    refute @tester.safeattr_defined?
+    assert_nil @tester.safeattr
+    @tester.safeattr = "a value"
+    assert @tester.safeattr_defined?
+    assert_equal "a value", @tester.safeattr
+  end
+
+  test "#threadsafe attributes inherit the value of the main thread" do
+    @tester.safeattr = "a value"
+    Thread.new do
+      assert @tester.safeattr_defined?
+      assert_equal "a value", @tester.safeattr
+    end.join
+    assert_equal "a value", @tester.safeattr
+  end
+
+  test "#changing a threadsafe attribute in a thread does not affect the main thread" do
+    @tester.safeattr = "a value"
+    Thread.new do
+      @tester.safeattr = "a new value"
+      assert_equal "a new value", @tester.safeattr
+    end.join
+    assert_equal "a value", @tester.safeattr
+  end
+
+end


### PR DESCRIPTION
This is just rebasing the changes in e9dc76b4aa on top of the current master. If we want to release this as a gem that is compatible with `shopify_api` we need it. Otherwise we get undefined method errors because the `ThreadsafeAttributes` module is missing

Please review @peterjm 
