### PR TITLE
Update requirements to patched active resource version

### DIFF
--- a/activeresource.gemspec
+++ b/activeresource.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('activesupport', '>= 4.0')
-  s.add_dependency('activemodel',   '>= 4.0')
+  s.add_dependency('activesupport', '>= 4.2.2')
+  s.add_dependency('activemodel',   '>= 4.2.2')
   s.add_dependency('rails-observers', '~> 0.1.2')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
@peterjm @chrisbutcher @EiNSTeiN- this is required in order to fix a bunch of dependencies in several other places.

I took `shopify_api` and made it depend on this branch and all the tests still passed. Just needed to make an update to `minitest` but most of it has been abstracted away so it was just changing some subclassing.
