### PR TITLE
Mark fork deprecated

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,9 @@
-= Active Resource {<img src="https://secure.travis-ci.org/rails/activeresource.png" />}[http://travis-ci.org/rails/activeresource]
+= [DEPRECATED]
+Shopify's fork of Active Resource is now deprecated.
+
+Please use the official version: https://github.com/rails/activeresource
+
+== Active Resource {<img src="https://secure.travis-ci.org/rails/activeresource.png" />}[http://travis-ci.org/rails/activeresource]
 
 Active Resource (ARes) connects business objects and Representational State Transfer (REST)
 web services.  It implements object-relational mapping for REST web services to provide transparent


### PR DESCRIPTION
As shown under https://github.com/shopify/shopify_api#threadsafety, this gem is unmaintained.

This PR updates the Readme to avoid confusion.

Ping @swalkinshaw @Shopify/api-documentation 